### PR TITLE
Enable active/inactive state for entities, fields and select options

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,10 @@
                             <input class="form-check-input" type="checkbox" id="entity-daily-progress-ref">
                             <label class="form-check-label" for="entity-daily-progress-ref">Usar como referencia de progreso diario</label>
                         </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="entity-active" checked>
+                            <label class="form-check-label" for="entity-active">Activo</label>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">
@@ -125,8 +129,11 @@
                         <div class="mb-3" id="options-container" style="display: none;">
                             <label class="form-label">Opciones</label>
                             <div id="options-list">
-                                <div class="input-group mb-2">
-                                    <input type="text" class="form-control field-option" placeholder="Opción">
+                                <div class="input-group mb-2 option-item">
+                                    <input type="text" class="form-control field-option-value" placeholder="Opción">
+                                    <div class="input-group-text">
+                                        <input class="form-check-input mt-0 option-active" type="checkbox" checked title="Activo">
+                                    </div>
                                     <button type="button" class="btn btn-outline-danger remove-option">×</button>
                                 </div>
                             </div>
@@ -183,6 +190,10 @@
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" id="field-daily-progress-ref">
                 <label class="form-check-label" for="field-daily-progress-ref">Usar como referencia de progreso diario</label>
+            </div>
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" id="field-active" checked>
+                <label class="form-check-label" for="field-active">Activo</label>
             </div>
                         </div>
                     </form>

--- a/js/models/entity.js
+++ b/js/models/entity.js
@@ -10,6 +10,14 @@ const EntityModel = {
         const data = StorageService.getData();
         return data && data.entities ? data.entities : [];
     },
+
+    /**
+     * Obtiene todas las entidades activas
+     * @returns {Array} Lista de entidades activas
+     */
+    getActive() {
+        return this.getAll().filter(ent => ent.active !== false);
+    },
     
     /**
      * Obtiene una entidad por su ID
@@ -28,7 +36,7 @@ const EntityModel = {
      * @param {boolean} [dailyProgressRef=false] Si la entidad es referencia para el progreso diario
      * @returns {Object} Entidad creada
      */
-    create(name, group = '', dailyProgressRef = false) {
+    create(name, group = '', dailyProgressRef = false, active = true) {
         const data = StorageService.getData();
         
         // Asegurarse de que data.entities existe
@@ -41,7 +49,8 @@ const EntityModel = {
             name: name,
             group: group,
             fields: [], // IDs de campos asignados
-            dailyProgressRef: !!dailyProgressRef
+            dailyProgressRef: !!dailyProgressRef,
+            active: !!active
         };
         
         data.entities.push(newEntity);
@@ -87,6 +96,9 @@ const EntityModel = {
         }
         if (updateData.hasOwnProperty('dailyProgressRef')) {
             entityToUpdate.dailyProgressRef = !!updateData.dailyProgressRef;
+        }
+        if (updateData.hasOwnProperty('active')) {
+            entityToUpdate.active = !!updateData.active;
         }
         // Se podrían añadir más propiedades aquí si fuera necesario en el futuro
         
@@ -144,6 +156,16 @@ const EntityModel = {
         const entities = this.getAll();
         // Obtener todos los grupos únicos que no estén vacíos
         const uniqueGroups = [...new Set(entities.map(entity => entity.group).filter(group => group))];
+        return uniqueGroups.sort();
+    },
+
+    /**
+     * Obtiene grupos solo de entidades activas
+     * @returns {Array} Lista de grupos
+     */
+    getActiveGroups() {
+        const entities = this.getActive();
+        const uniqueGroups = [...new Set(entities.map(e => e.group).filter(g => g))];
         return uniqueGroups.sort();
     },
     

--- a/js/models/field.js
+++ b/js/models/field.js
@@ -10,6 +10,14 @@ const FieldModel = {
         const data = StorageService.getData();
         return data && data.fields ? data.fields : [];
     },
+
+    /**
+     * Obtiene todos los campos activos
+     * @returns {Array} Lista de campos activos
+     */
+    getActive() {
+        return this.getAll().filter(f => f.active !== false);
+    },
     
     /**
      * Obtiene un campo por su ID
@@ -30,9 +38,18 @@ const FieldModel = {
         if (!ids || !Array.isArray(ids) || ids.length === 0) {
             return [];
         }
-        
+
         const fields = this.getAll();
         return fields.filter(field => field && ids.includes(field.id));
+    },
+
+    /**
+     * Obtiene varios campos activos por sus IDs
+     * @param {Array} ids Array de IDs de campos
+     * @returns {Array} Lista de campos activos
+     */
+    getActiveByIds(ids) {
+        return this.getByIds(ids).filter(f => f.active !== false);
     },
     
     /**
@@ -53,7 +70,15 @@ const FieldModel = {
             ...fieldData,
 
             dailySum: !!fieldData.dailySum,
-            dailyProgressRef: !!fieldData.dailyProgressRef
+            dailyProgressRef: !!fieldData.dailyProgressRef,
+            active: fieldData.hasOwnProperty('active') ? !!fieldData.active : true,
+            options: fieldData.type === 'select'
+                ? (fieldData.options || []).map(opt =>
+                    typeof opt === 'string' ? { value: opt, active: true } : {
+                        value: opt.value,
+                        active: opt.active !== false
+                    })
+                : []
         };
         
         data.fields.push(newField);
@@ -79,7 +104,13 @@ const FieldModel = {
             name: fieldData.name,
             type: fieldData.type,
             required: !!fieldData.required,
-            options: fieldData.type === 'select' ? (fieldData.options || []) : [],
+            options: fieldData.type === 'select'
+                ? (fieldData.options || []).map(opt =>
+                    typeof opt === 'string' ? { value: opt, active: true } : {
+                        value: opt.value,
+                        active: opt.active !== false
+                    })
+                : [],
             // Nuevas propiedades
             useForRecordsTable: !!fieldData.useForRecordsTable,
             isColumn3: !!fieldData.isColumn3,
@@ -90,7 +121,8 @@ const FieldModel = {
             isCompareField: !!fieldData.isCompareField,
 
             dailySum: !!fieldData.dailySum,
-            dailyProgressRef: !!fieldData.dailyProgressRef
+            dailyProgressRef: !!fieldData.dailyProgressRef,
+            active: fieldData.hasOwnProperty('active') ? !!fieldData.active : data.fields[fieldIndex].active !== false
         };
         
         StorageService.saveData(data);
@@ -150,7 +182,7 @@ const FieldModel = {
      */
     getDailySumField() {
         const fields = this.getAll() || [];
-        return fields.find(f => f.dailySum) || null;
+        return fields.find(f => f.dailySum && f.active !== false) || null;
     },
 
     /**
@@ -159,7 +191,7 @@ const FieldModel = {
      */
     getDailyProgressRefField() {
         const fields = this.getAll() || [];
-        return fields.find(f => f.dailyProgressRef) || null;
+        return fields.find(f => f.dailyProgressRef && f.active !== false) || null;
 
     }
 };

--- a/js/utils/ui.js
+++ b/js/utils/ui.js
@@ -144,10 +144,13 @@ const UIUtils = {
                 break;
                 
             case 'select':
-                const sortedOptions = [...field.options].sort(UIUtils.sortSelectOptions);
-                const options = sortedOptions.map(option =>
-                    `<option value="${option}" ${option === value ? 'selected' : ''}>${option}</option>`
-                ).join('');
+                const sortedOptions = [...(field.options || [])]
+                    .filter(opt => (typeof opt === 'object' ? opt.active !== false : true))
+                    .sort(UIUtils.sortSelectOptions);
+                const options = sortedOptions.map(opt => {
+                    const val = typeof opt === 'object' ? opt.value : opt;
+                    return `<option value="${val}" ${val === value ? 'selected' : ''}>${val}</option>`;
+                }).join('');
                 
                 // Crear un campo select con capacidad de búsqueda
                 inputHTML = `
@@ -355,12 +358,14 @@ const UIUtils = {
      * @returns {number} Resultado de la comparación
      */
     sortSelectOptions(a, b) {
-        const numA = parseFloat(a);
-        const numB = parseFloat(b);
+        const valA = typeof a === 'object' ? a.value : a;
+        const valB = typeof b === 'object' ? b.value : b;
+        const numA = parseFloat(valA);
+        const numB = parseFloat(valB);
         const isNumA = !isNaN(numA);
         const isNumB = !isNaN(numB);
         if (isNumA && isNumB) return numA - numB;
-        return a.localeCompare(b, 'es', { sensitivity: 'accent' });
+        return valA.localeCompare(valB, 'es', { sensitivity: 'accent' });
     },
     
     getEntityName(lowercase = false, plural = false) {

--- a/js/views/admin.js
+++ b/js/views/admin.js
@@ -114,6 +114,7 @@ const AdminView = {
                                                 <th>Nombre</th>
                                                 <th>Campos Asignados</th>
                                                 <th>Ref. Progreso</th>
+                                                <th>Activo</th>
                                                 <th>Acciones</th>
                                             </tr>
                                         </thead>
@@ -216,9 +217,10 @@ const AdminView = {
                                                 <th>Opciones</th>
                                                 <th>Para Reportes</th>
                                                 <th>Para Tabla</th>
-                                                <th>Suma Diaria</th>
-                                                <th>Ref. Progreso</th>
-                                                <th>Acciones</th>
+                                               <th>Suma Diaria</th>
+                                               <th>Ref. Progreso</th>
+                                                <th>Activo</th>
+                                               <th>Acciones</th>
                                             </tr>
                                         </thead>
                                         <tbody id="fields-list">
@@ -390,11 +392,13 @@ const AdminView = {
 
             const progressIndicator = entity.dailyProgressRef ? '<span class="badge bg-primary">Sí</span>' : '-';
 
+            const activeIndicator = entity.active !== false ? '<span class="badge bg-success">Sí</span>' : '<span class="badge bg-secondary">No</span>';
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td>${entity.name}</td>
                 <td>${fieldNames}</td>
                 <td class="text-center">${progressIndicator}</td>
+                <td class="text-center">${activeIndicator}</td>
                 <td class="action-buttons">
                     <button class="btn btn-sm btn-primary assign-fields" data-entity-id="${entity.id}">
                         Asignar Campos
@@ -474,7 +478,7 @@ const AdminView = {
             // Formatear opciones (solo para tipo selección)
             let options = '';
             if (field.type === 'select') {
-                options = field.options.join(', ');
+                options = field.options.map(opt => typeof opt === 'string' ? opt : opt.value).join(', ');
             } else {
                 options = '-';
             }
@@ -507,6 +511,7 @@ const AdminView = {
             const dailySumIndicator = field.dailySum ? '<span class="badge bg-primary">Sí</span>' : '-';
             const progressRefIndicator = field.dailyProgressRef ? '<span class="badge bg-primary">Sí</span>' : '-';
 
+            const activeIndicator = field.active !== false ? '<span class="badge bg-success">Sí</span>' : '<span class="badge bg-secondary">No</span>';
             row.innerHTML = `
                 <td>${field.name}</td>
                 <td>${fieldType}</td>
@@ -516,6 +521,7 @@ const AdminView = {
                 <td class="text-center">${tableIndicator}</td>
                 <td class="text-center">${dailySumIndicator}</td>
                 <td class="text-center">${progressRefIndicator}</td>
+                <td class="text-center">${activeIndicator}</td>
                 <td class="action-buttons">
                     <button class="btn btn-sm btn-outline-primary edit-field" data-field-id="${field.id}">
                         Editar
@@ -590,6 +596,7 @@ const AdminView = {
         const entityNameInput = document.getElementById('entity-name');
         const entityGroupInput = document.getElementById('entity-group');
         const dailyProgressRefCheck = document.getElementById('entity-daily-progress-ref');
+        const entityActiveCheck = document.getElementById('entity-active');
         const groupsDatalist = document.getElementById('existing-groups');
         
         // Obtener nombre personalizado
@@ -618,12 +625,14 @@ const AdminView = {
             entityNameInput.value = entity.name;
             entityGroupInput.value = entity.group || '';
             if (dailyProgressRefCheck) dailyProgressRefCheck.checked = entity.dailyProgressRef || false;
+            if (entityActiveCheck) entityActiveCheck.checked = entity.active !== false;
         } else {
             // Modo creación
             modalTitle.textContent = `Nueva ${entityName} Principal`;
             entityIdInput.value = '';
             entityGroupInput.value = '';
             if (dailyProgressRefCheck) dailyProgressRefCheck.checked = false;
+            if (entityActiveCheck) entityActiveCheck.checked = true;
         }
         
         modal.show();
@@ -671,6 +680,7 @@ const AdminView = {
         const entityName = document.getElementById('entity-name').value;
         const entityGroup = document.getElementById('entity-group').value.trim();
         const dailyProgressRef = document.getElementById('entity-daily-progress-ref').checked;
+        const entityActive = document.getElementById('entity-active').checked;
         
         // Obtener el nombre personalizado para entidad
         const config = StorageService.getConfig();
@@ -682,11 +692,12 @@ const AdminView = {
             result = EntityModel.update(entityId, {
                 name: entityName,
                 group: entityGroup,
-                dailyProgressRef: dailyProgressRef
+                dailyProgressRef: dailyProgressRef,
+                active: entityActive
             });
         } else {
             // Crear nueva entidad con la bandera indicada
-            result = EntityModel.create(entityName, entityGroup, dailyProgressRef);
+            result = EntityModel.create(entityName, entityGroup, dailyProgressRef, entityActive);
         }
 
         if (dailyProgressRef && result) {
@@ -778,12 +789,16 @@ const AdminView = {
         const isCompareFieldCheck = document.getElementById('field-is-compare-field');
         const dailySumCheck = document.getElementById('field-daily-sum');
         const dailyProgressRefCheck = document.getElementById('field-daily-progress-ref');
+        const fieldActiveCheck = document.getElementById('field-active');
         
         // Limpiar formulario
         document.getElementById('fieldForm').reset();
         optionsList.innerHTML = `
-            <div class="input-group mb-2">
-                <input type="text" class="form-control field-option" placeholder="Opción">
+            <div class="input-group mb-2 option-item">
+                <input type="text" class="form-control field-option-value" placeholder="Opción">
+                <div class="input-group-text">
+                    <input class="form-check-input mt-0 option-active" type="checkbox" checked title="Activo">
+                </div>
                 <button type="button" class="btn btn-outline-danger remove-option">×</button>
             </div>
         `;
@@ -850,7 +865,8 @@ const AdminView = {
             // Cargar opciones existentes
             if (field.type === 'select' && field.options.length > 0) {
                 optionsList.innerHTML = '';
-                field.options.forEach(option => {
+                field.options.forEach(opt => {
+                    const option = typeof opt === 'string' ? { value: opt, active: true } : opt;
                     this.addOptionInput(option);
                 });
             }
@@ -878,6 +894,7 @@ const AdminView = {
             if (dailyProgressRefCheck) {
                 dailyProgressRefCheck.checked = field.dailyProgressRef || false;
             }
+            if (fieldActiveCheck) fieldActiveCheck.checked = field.active !== false;
         } else {
             // Modo creación
             modalTitle.textContent = 'Nuevo Campo Personalizado';
@@ -886,6 +903,7 @@ const AdminView = {
             if (dailySumCheck) dailySumCheck.checked = false;
 
             if (dailyProgressRefCheck) dailyProgressRefCheck.checked = false;
+            if (fieldActiveCheck) fieldActiveCheck.checked = true;
 
         }
         
@@ -934,12 +952,15 @@ const AdminView = {
      * Agrega un input para una opción en el modal de campo
      * @param {string} value Valor inicial (opcional)
      */
-    addOptionInput(value = '') {
+    addOptionInput(option = { value: '', active: true }) {
         const optionsList = document.getElementById('options-list');
         const optionDiv = document.createElement('div');
-        optionDiv.className = 'input-group mb-2';
+        optionDiv.className = 'input-group mb-2 option-item';
         optionDiv.innerHTML = `
-            <input type="text" class="form-control field-option" placeholder="Opción" value="${value}">
+            <input type="text" class="form-control field-option-value" placeholder="Opción" value="${option.value}">
+            <div class="input-group-text">
+                <input class="form-check-input mt-0 option-active" type="checkbox" ${option.active ? 'checked' : ''} title="Activo">
+            </div>
             <button type="button" class="btn btn-outline-danger remove-option">×</button>
         `;
         
@@ -992,17 +1013,19 @@ const AdminView = {
         const dailySum = document.getElementById('field-daily-sum').checked;
 
         const dailyProgressRef = document.getElementById('field-daily-progress-ref').checked;
+        const fieldActive = document.getElementById('field-active').checked;
 
     
         // Recolectar opciones si es tipo selección
         let options = [];
         if (fieldType === 'select') {
-            const optionInputs = document.querySelectorAll('.field-option');
-            optionInputs.forEach(input => {
-                const value = input.value.trim();
-                if (value) options.push(value);
+            const optionItems = document.querySelectorAll('#options-list .option-item');
+            optionItems.forEach(div => {
+                const value = div.querySelector('.field-option-value').value.trim();
+                const active = div.querySelector('.option-active').checked;
+                if (value) options.push({ value, active });
             });
-    
+
             // Validar que haya al menos una opción
             if (options.length === 0) {
                 UIUtils.showAlert('Debe agregar al menos una opción para el tipo Selección', 'warning', document.querySelector('.modal-body'));
@@ -1084,7 +1107,8 @@ const AdminView = {
             isHorizontalAxis: isHorizontalAxis,
             isCompareField: isCompareField,
             dailySum: dailySum,
-            dailyProgressRef: dailyProgressRef
+            dailyProgressRef: dailyProgressRef,
+            active: fieldActive
 
         };
     

--- a/js/views/kpis.js
+++ b/js/views/kpis.js
@@ -219,11 +219,14 @@ const KPIsView = {
       if (!fieldId) return;
       const field = FieldModel.getById(fieldId);
       if (field && Array.isArray(field.options)) {
-        const options = [...field.options].sort(UIUtils.sortSelectOptions);
+        const options = field.options
+          .filter(opt => (typeof opt === 'object' ? opt.active !== false : true))
+          .sort(UIUtils.sortSelectOptions);
         options.forEach(opt => {
+          const val = typeof opt === 'object' ? opt.value : opt;
           const o = document.createElement('option');
-          o.value = opt;
-          o.textContent = opt;
+          o.value = val;
+          o.textContent = val;
           sel.appendChild(o);
         });
       }

--- a/js/views/register.js
+++ b/js/views/register.js
@@ -60,7 +60,7 @@ const RegisterView = {
                 return;
             }
 
-            const entities = EntityModel.getAll() || [];
+            const entities = EntityModel.getActive() || [];
 
             const entityButtons = entities.map(entity =>
                 `<button class="btn btn-outline-primary entity-btn mb-2 me-2" data-entity-id="${entity.id}">${entity.name}</button>`
@@ -279,7 +279,7 @@ const RegisterView = {
             console.warn("Contenedor de botones de entidad (.d-flex.flex-wrap) no encontrado dentro del contenedor principal.");
             // Puedes decidir si esto es un error crítico o no.
             // Si no hay entidades configuradas, este contenedor podría no existir o estar vacío.
-            const entities = EntityModel.getAll() || [];
+            const entities = EntityModel.getActive() || [];
             if (entities.length > 0) {
                 // Si hay entidades pero no se encontró el contenedor, es un problema de renderizado
                 console.error("Error crítico: Hay entidades pero no se encontró su contenedor en el DOM renderizado.");
@@ -346,7 +346,7 @@ const RegisterView = {
         }
 
         // Obtener campos asignados a la entidad
-        const fields = FieldModel.getByIds(entity.fields);
+        const fields = FieldModel.getActiveByIds(entity.fields);
         if (!fields || fields.length === 0) {
             dynamicFieldsContainer.innerHTML = `
                 <div class="alert alert-info">
@@ -407,9 +407,15 @@ const RegisterView = {
 
                 case 'select':
                     // Opciones ordenadas alfabética o numéricamente
-                    const sortedOpts = (field.options || []).slice().sort(UIUtils.sortSelectOptions);
+                    const sortedOpts = (field.options || [])
+                        .filter(opt => (typeof opt === 'object' ? opt.active !== false : true))
+                        .slice()
+                        .sort(UIUtils.sortSelectOptions);
                     const optionsHTML = [`<option value="">Seleccione...</option>`,
-                        ...sortedOpts.map(opt => `<option value="${opt}">${opt}</option>`)].join('');
+                        ...sortedOpts.map(opt => {
+                            const val = typeof opt === 'object' ? opt.value : opt;
+                            return `<option value="${val}">${val}</option>`;
+                        })].join('');
 
                     // Utilizar el componente de select con buscador sin ícono
                     fieldHTML += UIUtils.createSearchableSelect(field.id, optionsHTML, 'form-select', field.required ? 'required' : '');
@@ -598,7 +604,7 @@ const RegisterView = {
                 return;
             }
 
-            const fields = FieldModel.getByIds(entity.fields || []);
+            const fields = FieldModel.getActiveByIds(entity.fields || []);
 
             // Validar el formulario
             const validation = ValidationUtils.validateForm(form, fields);
@@ -1109,7 +1115,7 @@ const RegisterView = {
 
             // 2. Recargar botones de entidad (por si se añadieron/eliminaron/renombraron entidades)
             const entitySelector = document.querySelector('.d-flex.flex-wrap'); // Contenedor de botones
-            const entities = EntityModel.getAll() || [];
+            const entities = EntityModel.getActive() || [];
             if (entitySelector) {
                  const entityButtons = entities.map(entity =>
                     `<button class="btn btn-outline-primary entity-btn mb-2 me-2" data-entity-id="${entity.id}">${entity.name}</button>`

--- a/js/views/reports.js
+++ b/js/views/reports.js
@@ -893,7 +893,7 @@ const ReportsView = {
                 if (formattedDate.includes(searchText)) return true;
 
                 // Verificar en los datos del registro (incluyendo campos de columnas seleccionadas)
-                const fields = FieldModel.getAll(); // Obtener todos para buscar por nombre
+                const fields = FieldModel.getActive(); // Obtener todos para buscar por nombre
 
                 // Comprobar valores de las columnas seleccionadas
                 const col1Value = this.getFieldValue(record, this.selectedColumns.field1, fields);
@@ -953,7 +953,7 @@ const ReportsView = {
         const multiplier = direction === 'asc' ? 1 : -1;
 
         // Obtener todos los campos una vez para optimizar
-        const allFields = FieldModel.getAll();
+        const allFields = FieldModel.getActive();
 
         return [...records].sort((a, b) => {
             let valueA, valueB;
@@ -1200,7 +1200,7 @@ const ReportsView = {
         if (!hasRecords) return;
 
         // Obtener todos los campos una vez para optimizar
-        const allFields = FieldModel.getAll();
+        const allFields = FieldModel.getActive();
 
         // Renderizar cada registro
         records.forEach(record => {
@@ -1278,7 +1278,7 @@ const ReportsView = {
 
         const entity = EntityModel.getById(record.entityId) || { name: 'Desconocido' };
         const fields = FieldModel.getByIds(Object.keys(record.data)); // Campos usados en este registro
-        const allFields = FieldModel.getAll(); // Todos los campos para el selector de tipo
+        const allFields = FieldModel.getActive(); // Todos los campos para el selector de tipo
         // Obtener nombre personalizado de la entidad
         const config = StorageService.getConfig();
         const entityName = config.entityName || 'Entidad';
@@ -1446,7 +1446,7 @@ const ReportsView = {
             if (timestampDisplay) timestampDisplay.style.display = 'none';
             if (timestampEdit) timestampEdit.style.display = 'block';
 
-            const allFields = FieldModel.getAll();
+            const allFields = FieldModel.getActive();
 
             modalElement.querySelectorAll('#record-fields-container tbody tr').forEach(row => {
                 const displayCell = row.querySelector('.field-value-display');
@@ -2673,10 +2673,10 @@ const ReportsView = {
                 return;
             }
 
-            const entities = EntityModel.getAll();
+            const entities = EntityModel.getActive();
             // Mostrar todos los campos, no solo los numéricos
-            const allFields = FieldModel.getAll();
-            const sharedFields = FieldModel.getAll();
+            const allFields = FieldModel.getActive();
+            const sharedFields = FieldModel.getActive();
 
             // Formatear fechas
             const lastMonth = new Date();
@@ -2687,17 +2687,17 @@ const ReportsView = {
             const config = StorageService.getConfig();
             const entityName = config.entityName || 'Entidad';
 
-            const column3Field = FieldModel.getAll().find(field => field.isColumn3);
-            const column4Field = FieldModel.getAll().find(field => field.isColumn4);
-            const column5Field = FieldModel.getAll().find(field => field.isColumn5);
+            const column3Field = FieldModel.getActive().find(field => field.isColumn3);
+            const column4Field = FieldModel.getActive().find(field => field.isColumn4);
+            const column5Field = FieldModel.getActive().find(field => field.isColumn5);
 
             // Actualiza SelectedColumns al cargar si hay campos marcados
             this.selectedColumns.field1 = column3Field ? column3Field.id : '';
             this.selectedColumns.field2 = column4Field ? column4Field.id : '';
             this.selectedColumns.field3 = column5Field ? column5Field.id : '';
 
-            const horizontalAxisField = FieldModel.getAll().find(field => field.isHorizontalAxis);
-            const compareField = FieldModel.getAll().find(field => field.isCompareField);
+            const horizontalAxisField = FieldModel.getActive().find(field => field.isHorizontalAxis);
+            const compareField = FieldModel.getActive().find(field => field.isCompareField);
 
             // --- HTML Template Reorganizado ---
             let filtersHtml = '';
@@ -2783,7 +2783,7 @@ const ReportsView = {
                                                     
                                                     ${(() => {
                                                         // Obtener todos los grupos de entidades
-                                                        const groups = EntityModel.getAllGroups();
+                                                        const groups = EntityModel.getActiveGroups();
                                                         if (groups.length === 0) return ''; // No mostrar sección si no hay grupos
                                                         
                                                         return `
@@ -3101,7 +3101,7 @@ const ReportsView = {
                 optionsSelect.innerHTML = '<option value="">Todas las entidades</option>';
                 
                 // Cargar todas las entidades disponibles
-                const entities = EntityModel.getAll();
+                const entities = EntityModel.getActive();
                 console.log("Entidades disponibles:", entities.length);
                 
                 if (entities && entities.length > 0) {
@@ -3160,9 +3160,11 @@ const ReportsView = {
             
             // Añadir las opciones del campo select
             field.options.forEach(option => {
+                const opt = typeof option === 'object' ? option : { value: option, active: true };
+                if (opt.active === false) return;
                 const optElement = document.createElement('option');
-                optElement.value = option;
-                optElement.textContent = option;
+                optElement.value = opt.value;
+                optElement.textContent = opt.value;
                 optionsSelect.appendChild(optElement);
             });
             
@@ -3180,7 +3182,7 @@ const ReportsView = {
             
             // Obtener todos los campos disponibles excepto el seleccionado en eje horizontal
             const horizontalFieldId = horizontalFieldSelect.value;
-            const allFields = FieldModel.getAll();
+            const allFields = FieldModel.getActive();
             
             // Filtrar campos relevantes para análisis (numéricos, fechas, selects)
             const relevantFields = allFields.filter(field => 
@@ -3335,7 +3337,7 @@ const ReportsView = {
     autoGenerateReport() {
         try {
             // Verificar si hay campos disponibles para generar un reporte
-            const allFields = FieldModel.getAll();
+            const allFields = FieldModel.getActive();
             if (allFields.length === 0) {
                 console.log("No hay campos para generar reporte automático");
                 return; // No hay campos para generar reporte
@@ -3355,7 +3357,7 @@ const ReportsView = {
                 });
                 
                 // Obtener campos marcados para reportes comparativos
-                const compareField = FieldModel.getAll().find(field => field.isCompareField);
+                const compareField = FieldModel.getActive().find(field => field.isCompareField);
 
                 if (compareField) {
                     // Si hay un campo marcado para comparar, seleccionarlo


### PR DESCRIPTION
## Summary
- allow entities, fields and select options to be activated or deactivated
- show and edit active state in admin modals
- filter registration and reports to only use active items
- support active flag in select options
- update UI utilities for new option structure

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68480aef76188328835c5068a8c6e4c5