### PR TITLE
Add bulk field update support

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,10 @@
                             <label class="form-check-label" for="entity-daily-progress-ref">Usar como referencia de progreso diario</label>
                         </div>
                         <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="entity-mass-edit">
+                            <label class="form-check-label" for="entity-mass-edit">Habilitar para cambios masivos</label>
+                        </div>
+                        <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="entity-active" checked>
                             <label class="form-check-label" for="entity-active">Activo</label>
                         </div>
@@ -190,6 +194,10 @@
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" id="field-daily-progress-ref">
                 <label class="form-check-label" for="field-daily-progress-ref">Usar como referencia de progreso diario</label>
+            </div>
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" id="field-mass-edit">
+                <label class="form-check-label" for="field-mass-edit">Habilitar para cambios masivos</label>
             </div>
             <div class="form-check mt-2">
                 <input class="form-check-input" type="checkbox" id="field-active" checked>
@@ -338,6 +346,25 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                 <button type="button" class="btn btn-primary" id="saveBulkEdit">Guardar Cambios</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal para cambio masivo de campo -->
+<div class="modal fade" id="bulkFieldEditModal" tabindex="-1" aria-labelledby="bulkFieldEditModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="bulkFieldEditModalLabel">Editar Campo</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div id="bulk-field-edit-input"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-primary" id="saveBulkFieldEdit">Guardar Cambios</button>
             </div>
         </div>
     </div>

--- a/js/models/entity.js
+++ b/js/models/entity.js
@@ -37,7 +37,7 @@ const EntityModel = {
      * @param {boolean} [active=true] Indica si la entidad inicia activa
      * @returns {Object} Entidad creada
      */
-    create(name, group = '', dailyProgressRef = false, active = true) {
+    create(name, group = '', dailyProgressRef = false, active = true, massEdit = false) {
         const data = StorageService.getData();
         
         // Asegurarse de que data.entities existe
@@ -51,6 +51,7 @@ const EntityModel = {
             group: group,
             fields: [], // IDs de campos asignados
             dailyProgressRef: !!dailyProgressRef,
+            massEdit: !!massEdit,
             active: !!active
         };
         
@@ -97,6 +98,9 @@ const EntityModel = {
         }
         if (updateData.hasOwnProperty('dailyProgressRef')) {
             entityToUpdate.dailyProgressRef = !!updateData.dailyProgressRef;
+        }
+        if (updateData.hasOwnProperty('massEdit')) {
+            entityToUpdate.massEdit = !!updateData.massEdit;
         }
         if (updateData.hasOwnProperty('active')) {
             entityToUpdate.active = !!updateData.active;
@@ -196,5 +200,15 @@ const EntityModel = {
     getDailyProgressRefEntity() {
         const entities = this.getAll() || [];
         return entities.find(e => e.dailyProgressRef) || null;
+    },
+
+    /**
+     * Devuelve la entidad habilitada para cambios masivos
+     * @returns {Object|null} Entidad con massEdit activo
+     */
+    getMassEditEntity() {
+        const entities = this.getAll() || [];
+        return entities.find(e => e.massEdit) || null;
+
     }
 };

--- a/js/models/field.js
+++ b/js/models/field.js
@@ -86,6 +86,7 @@ const FieldModel = {
 
             dailySum: !!fieldData.dailySum,
             dailyProgressRef: !!fieldData.dailyProgressRef,
+            massEdit: !!fieldData.massEdit,
             active: fieldData.hasOwnProperty('active') ? !!fieldData.active : true,
             options: fieldData.type === 'select'
                 ? this._normalizeOptions(fieldData.options)
@@ -130,6 +131,7 @@ const FieldModel = {
 
             dailySum: !!fieldData.dailySum,
             dailyProgressRef: !!fieldData.dailyProgressRef,
+            massEdit: !!fieldData.massEdit,
             active: fieldData.hasOwnProperty('active') ? !!fieldData.active : data.fields[fieldIndex].active !== false
         };
         
@@ -201,6 +203,15 @@ const FieldModel = {
     getDailyProgressRefField() {
         const fields = this.getAll() || [];
         return fields.find(f => f.dailyProgressRef && f.active !== false) || null;
+    },
+
+    /**
+     * Devuelve el campo habilitado para cambios masivos
+     * @returns {Object|null} Campo con massEdit activo
+     */
+    getMassEditField() {
+        const fields = this.getAll() || [];
+        return fields.find(f => f.massEdit && f.active !== false) || null;
 
     }
 };

--- a/js/models/record.js
+++ b/js/models/record.js
@@ -474,7 +474,7 @@ const RecordModel = {
      * @param {string} newDate Nueva fecha (en formato ISO)
      * @returns {boolean} true si se actualizó correctamente, false si no
      */
-    update(id, newData, newDate) {
+    update(id, newData, newDate, newEntityId) {
         const data = StorageService.getData();
         const recordIndex = data.records.findIndex(record => record.id === id);
         
@@ -488,6 +488,10 @@ const RecordModel = {
         // Actualizar la fecha si se proporciona
         if (newDate) {
             data.records[recordIndex].timestamp = newDate;
+        }
+
+        if (newEntityId) {
+            data.records[recordIndex].entityId = newEntityId;
         }
         
         // Guardar los cambios


### PR DESCRIPTION
## Summary
- allow marking entities and fields for mass edits
- expose mass edit data in admin tables
- add UI checkboxes and button for bulk field changes
- support updating entityId in records

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba670acc8328abb6334eae338ff5