### PR TITLE
Enhance KPI view with insights configuration

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -336,3 +336,15 @@ body {
 #kpi-config-form .form-check.col { /* Ensure good spacing for checkboxes */
     margin-bottom: 0.5rem;
 }
+
+/* Insights Table Styling */
+#kpi-insights table thead th {
+    background-color: #f8f9fa;
+    font-weight: 600;
+}
+#kpi-insights table tbody tr:nth-child(odd) {
+    background-color: rgba(0,0,0,0.02);
+}
+#kpi-insights table tbody tr:hover {
+    background-color: rgba(0,0,0,0.04);
+}


### PR DESCRIPTION
## Summary
- add configurable insights section to KPI view
- allow selecting fields for insights in KPI settings
- show insights tables comparing current and previous periods
- style insights table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863c28075a8832880e9bf8778e8a23f