### PR TITLE
Fix: Remove lingering kpis2.js script include

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
     <script src="js/views/register.js"></script>
     <script src="js/views/reports.js"></script>
     <script src="js/views/kpis.js"></script>
-    <script src="js/views/kpis2.js"></script>
+    <!-- <script src="js/views/kpis2.js"></script> --> <!-- File causes 404, route removed -->
     <script src="js/router.js"></script>
     <script src="js/app.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>


### PR DESCRIPTION
- Commented out the direct script include for js/views/kpis2.js in index.html.
- Verified that references to kpis2 and KPIs2View in js/router.js were already commented out.
- This should resolve the persistent 404 error for kpis2.js, assuming no caching or deployment issues on the user's end.