### PR TITLE
Enable editing of record's entity

### DIFF
--- a/js/models/record.js
+++ b/js/models/record.js
@@ -474,7 +474,7 @@ const RecordModel = {
      * @param {string} newDate Nueva fecha (en formato ISO)
      * @returns {boolean} true si se actualizó correctamente, false si no
      */
-    update(id, newData, newDate) {
+    update(id, newData, newDate, newEntityId = null) {
         const data = StorageService.getData();
         const recordIndex = data.records.findIndex(record => record.id === id);
         
@@ -488,6 +488,11 @@ const RecordModel = {
         // Actualizar la fecha si se proporciona
         if (newDate) {
             data.records[recordIndex].timestamp = newDate;
+        }
+
+        // Actualizar la entidad si se proporciona
+        if (newEntityId) {
+            data.records[recordIndex].entityId = newEntityId;
         }
         
         // Guardar los cambios

--- a/js/views/reports.js
+++ b/js/views/reports.js
@@ -1291,6 +1291,7 @@ const ReportsView = {
         // Obtener nombre personalizado de la entidad
         const config = StorageService.getConfig();
         const entityName = config.entityName || 'Entidad';
+        const entities = EntityModel.getActive();
 
         // Usar UIUtils para obtener o crear el modal
         const modalElement = document.getElementById('viewRecordModal');
@@ -1305,7 +1306,10 @@ const ReportsView = {
             <div class="mb-3 row">
                 <strong class="col-sm-3 col-form-label">${entityName}:</strong>
                 <div class="col-sm-9">
-                    <input type="text" readonly class="form-control-plaintext" value="${entity.name}">
+                    <span id="record-entity-display">${entity.name}</span>
+                    <select id="record-entity-edit" class="form-select form-select-sm" style="display:none;">
+                        ${entities.map(ent => `<option value="${ent.id}" ${ent.id === entity.id ? 'selected' : ''}>${ent.name}</option>`).join('')}
+                    </select>
                 </div>
             </div>
             <div class="mb-3 row">
@@ -1458,6 +1462,11 @@ const ReportsView = {
             if (timestampDisplay) timestampDisplay.style.display = 'none';
             if (timestampEdit) timestampEdit.style.display = 'block';
 
+            const entityDisplay = modalElement.querySelector('#record-entity-display');
+            const entityEdit = modalElement.querySelector('#record-entity-edit');
+            if (entityDisplay) entityDisplay.style.display = 'none';
+            if (entityEdit) entityEdit.style.display = 'block';
+
             const allFields = FieldModel.getActive();
 
             modalElement.querySelectorAll('#record-fields-container tbody tr').forEach(row => {
@@ -1525,10 +1534,15 @@ const ReportsView = {
          if (recordId) {
               this.showRecordDetails(recordId);
          } else {
-              const timestampDisplay = modalElement.querySelector('#record-timestamp-display');
-              const timestampEdit = modalElement.querySelector('#record-timestamp-edit');
-              if(timestampDisplay) timestampDisplay.style.display = 'inline';
-              if(timestampEdit) timestampEdit.style.display = 'none';
+             const timestampDisplay = modalElement.querySelector('#record-timestamp-display');
+             const timestampEdit = modalElement.querySelector('#record-timestamp-edit');
+             if(timestampDisplay) timestampDisplay.style.display = 'inline';
+             if(timestampEdit) timestampEdit.style.display = 'none';
+
+             const entityDisplay = modalElement.querySelector('#record-entity-display');
+             const entityEdit = modalElement.querySelector('#record-entity-edit');
+             if(entityDisplay) entityDisplay.style.display = 'inline';
+             if(entityEdit) entityEdit.style.display = 'none';
 
               modalElement.querySelectorAll('#record-fields-container tbody tr').forEach(row => {
                   const displayCell = row.querySelector('.field-value-display');
@@ -1611,8 +1625,12 @@ const ReportsView = {
         // Convertir a formato ISO
         const newDate = new Date(newTimestamp).toISOString();
 
+        // Obtener la nueva entidad
+        const entitySelect = document.getElementById('record-entity-edit');
+        const newEntityId = entitySelect ? entitySelect.value : null;
+
         // Actualizar el registro
-        const success = RecordModel.update(recordId, fieldsData, newDate);
+        const success = RecordModel.update(recordId, fieldsData, newDate, newEntityId);
 
         if (success) {
             // Salir del modo edición y mostrar los datos actualizados


### PR DESCRIPTION
## Summary
- allow RecordModel.update to change record entity
- show dropdown to edit entity in record details modal
- toggle entity controls in edit mode
- save updated entity when saving record changes

## Testing
- `node --check js/views/reports.js`
- `node --check js/models/record.js`


------
https://chatgpt.com/codex/tasks/task_e_686b7be1e678832881ed8db343c18d0e